### PR TITLE
Read MBR filesystem label for getBootPartition()

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "yauzl": "^2.10.0"
   },
   "dependencies": {
-    "balena-image-fs": "^7.0.6",
+    "balena-image-fs": "^7.4.0",
     "file-disk": "^8.0.1",
     "partitioninfo": "^6.0.2"
   },


### PR DESCRIPTION
Use latest balena-image-fs for MBR partitions so `getBootPartition()` can find partition by partition label rather than contents.